### PR TITLE
fix some problems and support mset 

### DIFF
--- a/r3c.cpp
+++ b/r3c.cpp
@@ -2329,42 +2329,28 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                 redis_context = redisConnectWithTimeout(node->first.c_str(), node->second, connect_timeout);
             }
 
+			
+
+            _redis_context = redis_context;
             if (NULL == redis_context)
             {
                 (*g_error_log)("[%s:%d][standalone]redisConnect failed\n", __FILE__, __LINE__, slot);
             }
-            else
+            else if (_data_timeout_milliseconds > 0)
             {
-                if (_password.size() > 0)
-                {
-                    redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-                    if (NULL == redis_reply)
-                    {
-                        (*g_error_log)("[%s:%d]auth failure, err=%s\n",
-                            __FILE__, __LINE__, redis_context->errstr);
-                        redisFree(redis_context);
-                        return NULL;
-                    }
-                    if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
-                    {
-                        (*g_error_log)("[%s:%d]auth failure, reply err=%s\n",
-                            __FILE__, __LINE__, redis_reply->str);
-                        freeReplyObject(redis_reply);
-                        redisFree(redis_context);
-                        return NULL;
-                    }
-                    freeReplyObject(redis_reply);
-                }
+				if(_password.size() > 0)
+				{
+					redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+					if (NULL == redis_reply)
+					{
+						(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
+					}
 
-                if (_data_timeout_milliseconds > 0)
-                {
-                    struct timeval data_timeout;
-                    data_timeout.tv_sec = _data_timeout_milliseconds / 1000;
-                    data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
-                    redisSetTimeout(redis_context, data_timeout);
-                }
-
-                _redis_context = redis_context;
+				}
+                struct timeval data_timeout;
+                data_timeout.tv_sec = _data_timeout_milliseconds / 1000;
+                data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
+                redisSetTimeout(redis_context, data_timeout);
             }
         }
     }
@@ -2419,27 +2405,18 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                             (*g_error_log)("[%s:%d]slot[%u] redisConnect failed\n", __FILE__, __LINE__, slot);
                         }
                         else
-                        {
-                            if (_password.size() > 0)
-                            {
-                                redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-                                if (NULL == redis_reply)
-                                {
-                                    (*g_error_log)("[%s:%d]auth failure, err=%s\n",
-                                        __FILE__, __LINE__, redis_context->errstr);
-                                    redisFree(redis_context);
-                                    return NULL;
-                                }
-                                if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
-                                {
-                                    (*g_error_log)("[%s:%d]auth failure, reply err=%s\n",
-                                        __FILE__, __LINE__, redis_reply->str);
-                                    freeReplyObject(redis_reply);
-                                    redisFree(redis_context);
-                                    return NULL;
-                                }
-                                freeReplyObject(redis_reply);
-                            }
+                        {                            
+							if(_password.size() > 0)
+							{
+								redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+								if (NULL == redis_reply)
+								{
+									(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
+								}
+
+							}
+                            slot_info->redis_context = redis_context;
+                            _redis_contexts.insert(std::make_pair(slot_info->node, redis_context));
 
                             if (_data_timeout_milliseconds > 0)
                             {
@@ -2448,9 +2425,6 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                                 data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
                                 redisSetTimeout(redis_context, data_timeout);
                             }
-
-                            slot_info->redis_context = redis_context;
-                            _redis_contexts.insert(std::make_pair(slot_info->node, redis_context));
                         }
                     }
                 } // if (slot_info->redis_context != NULL)
@@ -2511,23 +2485,12 @@ redisContext* CRedisClient::connect_node(int* errcode, std::string* errmsg, std:
         {
 			if(_password.size() > 0)
 			{
-                redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-                if (NULL == redis_reply)
-                {
-                    (*g_error_log)("[%s:%d]redisCommand auth failed, err=%s\n",
-                        __FILE__, __LINE__, redis_context->errstr);
-                    redisFree(redis_context);
-                    return NULL;
-                }
-                if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
-                {
-                    (*g_error_log)("[%s:%d][standalone]redisCommand auth failed, reply err=%s\n",
-                        __FILE__, __LINE__, redis_reply->str);
-                    freeReplyObject(redis_reply);
-                    redisFree(redis_context);
-                    return NULL;
-                }
-                freeReplyObject(redis_reply);
+				redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+				if (NULL == redis_reply)
+				{
+					(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
+				}
+
 			}
             if (0 == redis_context->err)
             {

--- a/r3c.cpp
+++ b/r3c.cpp
@@ -931,6 +931,14 @@ int64_t CRedisClient::mget(const std::vector<std::string>& keys, std::vector<std
     return redis_command(REDIS_REPLY_ARRAY, &param_info);
 }
 
+void CRedisClient::mset(const std::map<std::string, std::string>& kv_map,
+                        std::pair<std::string, uint16_t>* which) throw (CRedisException)
+{
+    struct ParamInfo param_info("MSET", sizeof("MSET")-1, NULL, which);
+    param_info.in_map1 = &kv_map;
+    (void)redis_command(REDIS_REPLY_STATUS, &param_info);
+}
+
 bool CRedisClient::del(const std::string& key, std::pair<std::string, uint16_t>* which) throw (CRedisException)
 {
     struct ParamInfo param_info("DEL", sizeof("DEL")-1, &key, which);
@@ -2329,28 +2337,42 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                 redis_context = redisConnectWithTimeout(node->first.c_str(), node->second, connect_timeout);
             }
 
-			
-
-            _redis_context = redis_context;
             if (NULL == redis_context)
             {
                 (*g_error_log)("[%s:%d][standalone]redisConnect failed\n", __FILE__, __LINE__, slot);
             }
-            else if (_data_timeout_milliseconds > 0)
+            else
             {
-				if(_password.size() > 0)
-				{
-					redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-					if (NULL == redis_reply)
-					{
-						(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
-					}
+                if (_password.size() > 0)
+                {
+                    redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+                    if (NULL == redis_reply)
+                    {
+                        (*g_error_log)("[%s:%d]auth failure, err=%s\n",
+                            __FILE__, __LINE__, redis_context->errstr);
+                        redisFree(redis_context);
+                        return NULL;
+                    }
+                    if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
+                    {
+                        (*g_error_log)("[%s:%d]auth failure, reply err=%s\n",
+                            __FILE__, __LINE__, redis_reply->str);
+                        freeReplyObject(redis_reply);
+                        redisFree(redis_context);
+                        return NULL;
+                    }
+                    freeReplyObject(redis_reply);
+                }
 
-				}
-                struct timeval data_timeout;
-                data_timeout.tv_sec = _data_timeout_milliseconds / 1000;
-                data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
-                redisSetTimeout(redis_context, data_timeout);
+                if (_data_timeout_milliseconds > 0)
+                {
+                    struct timeval data_timeout;
+                    data_timeout.tv_sec = _data_timeout_milliseconds / 1000;
+                    data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
+                    redisSetTimeout(redis_context, data_timeout);
+                }
+
+                _redis_context = redis_context;
             }
         }
     }
@@ -2405,18 +2427,27 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                             (*g_error_log)("[%s:%d]slot[%u] redisConnect failed\n", __FILE__, __LINE__, slot);
                         }
                         else
-                        {                            
-							if(_password.size() > 0)
-							{
-								redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-								if (NULL == redis_reply)
-								{
-									(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
-								}
-
-							}
-                            slot_info->redis_context = redis_context;
-                            _redis_contexts.insert(std::make_pair(slot_info->node, redis_context));
+                        {
+                            if (_password.size() > 0)
+                            {
+                                redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+                                if (NULL == redis_reply)
+                                {
+                                    (*g_error_log)("[%s:%d]auth failure, err=%s\n",
+                                        __FILE__, __LINE__, redis_context->errstr);
+                                    redisFree(redis_context);
+                                    return NULL;
+                                }
+                                if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
+                                {
+                                    (*g_error_log)("[%s:%d]auth failure, reply err=%s\n",
+                                        __FILE__, __LINE__, redis_reply->str);
+                                    freeReplyObject(redis_reply);
+                                    redisFree(redis_context);
+                                    return NULL;
+                                }
+                                freeReplyObject(redis_reply);
+                            }
 
                             if (_data_timeout_milliseconds > 0)
                             {
@@ -2425,6 +2456,9 @@ redisContext* CRedisClient::get_redis_context(unsigned int slot, std::pair<std::
                                 data_timeout.tv_usec = (_data_timeout_milliseconds % 1000) * 1000;
                                 redisSetTimeout(redis_context, data_timeout);
                             }
+
+                            slot_info->redis_context = redis_context;
+                            _redis_contexts.insert(std::make_pair(slot_info->node, redis_context));
                         }
                     }
                 } // if (slot_info->redis_context != NULL)
@@ -2485,12 +2519,23 @@ redisContext* CRedisClient::connect_node(int* errcode, std::string* errmsg, std:
         {
 			if(_password.size() > 0)
 			{
-				redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
-				if (NULL == redis_reply)
-				{
-					(*g_error_log)("[%s:%d]auth failure\n", __FILE__, __LINE__);		
-				}
-
+                redisReply* redis_reply = (redisReply*)redisCommand(redis_context, "auth %s", _password.c_str());
+                if (NULL == redis_reply)
+                {
+                    (*g_error_log)("[%s:%d]redisCommand auth failed, err=%s\n",
+                        __FILE__, __LINE__, redis_context->errstr);
+                    redisFree(redis_context);
+                    return NULL;
+                }
+                if (REDIS_REPLY_STATUS != redis_reply->type || 0 != strcasecmp(redis_reply->str, "OK"))
+                {
+                    (*g_error_log)("[%s:%d][standalone]redisCommand auth failed, reply err=%s\n",
+                        __FILE__, __LINE__, redis_reply->str);
+                    freeReplyObject(redis_reply);
+                    redisFree(redis_context);
+                    return NULL;
+                }
+                freeReplyObject(redis_reply);
 			}
             if (0 == redis_context->err)
             {

--- a/r3c.h
+++ b/r3c.h
@@ -300,6 +300,8 @@ public:
     bool get(const std::string& key, std::string* value, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     int64_t mget(const std::vector<std::string>& keys, std::vector<std::string>* values,
         std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
+    void mset(const std::map<std::string, std::string>& kv_map,
+        std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     bool del(const std::string& key, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     int64_t incrby(const std::string& key, int64_t increment, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
 
@@ -334,8 +336,6 @@ public:
     int hmdel(const std::string& key, const std::vector<std::string>& fields, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     bool hexists(const std::string& key, const std::string& field, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     int hlen(const std::string& key, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
-
-    // if field not exists return true, or return false
     bool hset(const std::string& key, const std::string& field, const std::string& value, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     bool hsetex(const std::string& key, const std::string& field, const std::string& value, uint32_t timeout_seconds, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);
     bool hsetnx(const std::string& key, const std::string& field, const std::string& value, std::pair<std::string, uint16_t>* which=NULL) throw (CRedisException);


### PR DESCRIPTION
1. free redis handle when the command “auth” fail， avoid core when
deconstruct.
2. support mset.