### PR TITLE
修改zrangebyscore和xread接口命令和参数错误

### DIFF
--- a/r3c.cpp
+++ b/r3c.cpp
@@ -2869,7 +2869,7 @@ int CRedisClient::zrangebyscore(
         int num_retries)
 {
     CommandArgs cmd_args;
-    cmd_args.add_arg("ZREVRANGEBYSCORE");
+    cmd_args.add_arg("ZRANGEBYSCORE");
     cmd_args.add_arg(key);
     cmd_args.add_arg(min);
     cmd_args.add_arg(max);
@@ -3390,7 +3390,7 @@ void CRedisClient::xreadgroup(
     std::vector<std::string> ids(1);
 
     keys[0] = key;
-    ids[0] = ">";
+    ids[0] = "$";
     xreadgroup(groupname, consumername, keys, ids, count, block_milliseconds, noack, &streams, which, num_retries);
     if (!streams.empty())
         values->swap(streams[0].entries);


### PR DESCRIPTION
1.zrangebyscore应该使用ZRANGEBYSCORE命令
2.xread读取特殊ID">"返回错误，应该是读取最新消息，使用特殊ID“$”